### PR TITLE
simplejson fix

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,1 +1,1 @@
-simplejson==3.17.2
+simplejson==3.18.1


### PR DESCRIPTION
Lambda threws error when executing`os.system('/var/lang/bin/pip3.9 install office365 -t /tmp/')`: 
```
awslambdaric 2.0.4 requires simplejson==3.17.2, but you have simplejson 3.18.1 which is incompatible.
```


